### PR TITLE
Capture compiler output in with-err-str-cb

### DIFF
--- a/src/clj_assorted_utils/util.clj
+++ b/src/clj_assorted_utils/util.clj
@@ -525,9 +525,13 @@
    cb-fn is executed after the element was added to the writer."
   [cb-fn & body]
   `(let [wrtr# (proxy [java.io.StringWriter] []
-                 (write [^String s#]
-                   (proxy-super write s#)
-                   (~cb-fn s#)))]
+                 (write
+                   ([^String s#]
+                    (proxy-super write s#)
+                    (~cb-fn s#))
+                   ([^String s# off# len#]
+                    (proxy-super write s# off# len#)
+                    (~cb-fn s#))))]
      (binding [*err* wrtr#]
        ~@body
        (str wrtr#))))


### PR DESCRIPTION
## Overview
The Clojure compiler invokes the [3-arity method](http://cs.gettysburg.edu/java/docs/api/java/io/StringWriter.html#write-java.lang.String-int-int-) of
`java.io.StringWriter/write` when writing warning messages to
`*err*`.

## Notes
- I refactored the existing `with-eo-str-test` to use map destructuring. If you prefer that I not use destructuring, I'm happy to amend the commit to match the former style.